### PR TITLE
使用gradio配置前端页面，方便配置参数

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,0 +1,48 @@
+import gradio as gr
+import importlib
+from utils import common
+from utils import logger
+
+# TODO：gradio的TextBox不能用dict接收（user_config["platform"]获取会返回TextBox而不是string），暂时没有好的解决方法
+
+def start_server(*inputs):
+    # 构建json数据
+    user_config = common.build_user_config(inputs)
+
+    # 根据直播平台类型不同启动不同的Server
+    platform = user_config["platform"]
+    if len(platform) > 0:
+        importlib.import_module(platform).start_server(user_config)
+    else:
+        exit(0)
+
+
+# 配置窗口
+with gr.Blocks() as config:
+    # 输入列表
+    input = []
+
+    # 严格按照config_list.txt的顺序
+    with gr.Row():
+        with gr.Tab("基础信息输入"):
+            input.append(gr.Dropdown(label="直播平台类型", choices=common.get_support_platform()))
+            input.append(gr.Textbox(label="直播间房间号"))
+            input.append(gr.Dropdown(label="聊天模式",choices=['chatterbot', 'gpt', 'claude', 'langchain_pdf', 'langchain_pdf+gpt', 'none']))
+            input.append(gr.Dropdown(label="弹幕语言筛选", choices=['none', 'en', 'jp', 'zh']))
+            input.append(gr.Textbox(label="前提限制prompt"))
+            input.append(gr.Textbox(label="后置限制prompt"))
+            input.append(gr.Textbox(label="最长阅读的英文单词数（空格分隔）"))
+            input.append(gr.Textbox(label="最长阅读的字符数，双重过滤，避免溢出"))
+
+    button = gr.Button("确认")
+    button.click(
+        fn=start_server, inputs=input
+    )
+
+    logs = gr.Textbox()
+
+    with gr.Row():
+        config.load(logger.read_logs, None, logs, every=1)
+
+config.queue().launch()
+

--- a/bilibili.py
+++ b/bilibili.py
@@ -3,33 +3,32 @@ from bilibili_api import live, sync
 
 from utils.my_handle import My_handle
 
-my_handle = My_handle("config.json")
-if my_handle is None:
-    print("程序初始化失败！")
-    exit(0)
 
+def start_server(userConfig):
+    my_handle = My_handle("config.json", userConfig)
+    if my_handle is None:
+        print("程序初始化失败！")
+        exit(0)
 
-# 初始化 Bilibili 直播间
-room = live.LiveDanmaku(my_handle.get_room_id())
+    # 初始化 Bilibili 直播间
+    room = live.LiveDanmaku(my_handle.get_room_id())
 
+    @room.on('DANMU_MSG')
+    async def on_danmaku(event):
+        """
+        处理直播间弹幕事件
+        :param event: 弹幕事件数据
+        """
+        content = event["data"]["info"][1]  # 获取弹幕内容
+        user_name = event["data"]["info"][2][1]  # 获取发送弹幕的用户昵称
 
-@room.on('DANMU_MSG')
-async def on_danmaku(event):
-    """
-    处理直播间弹幕事件
-    :param event: 弹幕事件数据
-    """
-    content = event["data"]["info"][1]  # 获取弹幕内容
-    user_name = event["data"]["info"][2][1]  # 获取发送弹幕的用户昵称
+        my_handle.commit_handle(user_name, content)
 
-    my_handle.commit_handle(user_name, content)
-
-
-try: 
-    # 启动 Bilibili 直播间连接
-    sync(room.connect())
-except KeyboardInterrupt:
-    print('程序被强行退出')
-finally:
-    print('关闭连接...')
-    exit(0)
+    try:
+        # 启动 Bilibili 直播间连接
+        sync(room.connect())
+    except KeyboardInterrupt:
+        print('程序被强行退出')
+    finally:
+        print('关闭连接...')
+        exit(0)

--- a/config.json
+++ b/config.json
@@ -1,4 +1,5 @@
 {
+  "platform" : "直播平台类型",
   "room_display_id": "你的直播间房间号",
   "chat_type": "none",
   "need_lang": "none",

--- a/config/config_list.txt
+++ b/config/config_list.txt
@@ -1,0 +1,8 @@
+platform
+room_display_id
+chat_type
+need_lang
+before_promet
+after_promet
+max_len
+max_char_len

--- a/config/support_platform.txt
+++ b/config/support_platform.txt
@@ -1,0 +1,3 @@
+bilibili
+dy
+ks

--- a/dy.py
+++ b/dy.py
@@ -28,7 +28,7 @@ import json, re
 from utils.my_handle import My_handle
 
 
-my_handle = My_handle("config.json")
+my_handle = My_handle("config.json", None)
 if my_handle is None:
     print("程序初始化失败！")
     exit(0)

--- a/ks.py
+++ b/ks.py
@@ -27,7 +27,7 @@ from ks_pb2 import SCWebEnterRoomAck
 
 from utils.my_handle import My_handle
 
-my_handle = My_handle("config.json")
+my_handle = My_handle("config.json", None)
 if my_handle is None:
     print("程序初始化失败！")
     exit(0)

--- a/utils/common.py
+++ b/utils/common.py
@@ -9,6 +9,7 @@ import langid
 
 from profanity import profanity
 
+
 class Common:
     # 获取北京时间
     def get_bj_time(self, type=0):
@@ -41,7 +42,7 @@ class Common:
             second = now.tm_sec  # 获取当前秒数
 
             return str(second)
-    
+
     # 删除多余单词
     def remove_extra_words(self, text="", max_len=30, max_char_len=50):
         words = text.split()
@@ -49,7 +50,6 @@ class Common:
             words = words[:max_len]  # 列表切片，保留前30个单词
             text = ' '.join(words) + '...'  # 使用join()函数将单词列表重新组合为字符串，并在末尾添加省略号
         return text[:max_char_len]
-
 
     # 本地敏感词检测 传入敏感词库文件路径和待检查的文本
     def check_sensitive_words(self, file_path, text):
@@ -62,7 +62,6 @@ class Common:
 
         return False
 
-
     # 链接检测
     def is_url_check(self, text):
         url_pattern = re.compile(r'(?i)((?:(?:https?|ftp):\/\/)?[^\s/$.?#]+\.[^\s>]+)')
@@ -71,7 +70,6 @@ class Common:
             return True
         else:
             return False
-
 
     # 语言检测
     def lang_check(self, text, need="none"):
@@ -86,14 +84,47 @@ class Common:
             else:
                 return language
 
-
     # 判断字符串是否全为标点符号
     def is_punctuation_string(self, string):
         # 使用正则表达式匹配标点符号
         pattern = r'^[^\w\s]+$'
         return re.match(pattern, string) is not None
-    
 
     # 违禁词校验
     def profanity_content(self, content):
         return profanity.contains_profanity(content)
+
+
+config_list = 'config/config_list.txt'
+support_platform = 'config/support_platform.txt'
+
+
+# 加载支持的平台
+def get_support_platform():
+    platform = []
+    with open(support_platform) as f:
+        platform = [line.rstrip('\n') for line in f]
+    return platform
+
+
+# 加载配置文件的key
+def load_config_key():
+    keys = []
+    with open(config_list, 'r') as f:
+        keys = [line.rstrip('\n') for line in f]
+        # for line in f:
+        #     keys.append(line.strip('\n').split(','))
+    return keys
+
+
+# 根据用户自定义配置文件组装dict
+def build_user_config(values):
+    keys = load_config_key()
+    user_config = {}
+
+    i = 0
+    for key in keys:
+        user_config[key] = values[i]
+        i += 1
+
+    return user_config

--- a/utils/config.py
+++ b/utils/config.py
@@ -21,3 +21,8 @@ class Config:
             if result is None:
                 break
         return result
+
+    def update(self, json):
+        if len(json) > 0:
+            print(json)
+            self.config.update(json)

--- a/utils/logger.py
+++ b/utils/logger.py
@@ -1,0 +1,31 @@
+import gradio as gr
+import sys
+
+
+# 将运行结果实时输出到gradio的textBox中
+
+class Logger:
+    def __init__(self, filename):
+        self.terminal = sys.stdout
+        self.log = open(filename, "w")
+
+    def write(self, message):
+        self.terminal.write(message)
+        self.log.write(message)
+
+    def flush(self):
+        self.terminal.flush()
+        self.log.flush()
+
+    def isatty(self):
+        return False
+
+
+terminal_log = "log/terminal.log"
+sys.stdout = Logger(terminal_log)
+
+
+def read_logs():
+    sys.stdout.flush()
+    with open(terminal_log, "r") as f:
+        return f.read()

--- a/utils/my_handle.py
+++ b/utils/my_handle.py
@@ -1,3 +1,4 @@
+import json
 import os
 import logging
 
@@ -56,7 +57,7 @@ class My_handle():
     log_file_path = None
 
 
-    def __init__(self, config_path):
+    def __init__(self, config_path, userConfig):
         LOG_FORMAT = "%(asctime)s - %(levelname)s - %(message)s"
         # logging.basicConfig(level=logging.DEBUG, format=LOG_FORMAT)
         # 不想看那么多日志信息，可以把日志等级提一提
@@ -65,6 +66,11 @@ class My_handle():
         
         self.common = Common()
         self.config = Config(config_path)
+
+        # 如果存在用户自定义config, 更新配置
+        if len(userConfig) > 0:
+            self.config.update(userConfig)
+
         self.audio = Audio()
 
         self.proxy = None


### PR DESCRIPTION
说明：
1. 通过app.py启动项目
2. 目前只支持bilibili，dy和ks暂时没有实现
3. 目前前端只支持部分配置，claude和gpt等模型连接的嵌套json格式暂时不知道怎么处理
4. config/config_list.txt 中的配置信息要严格按照顺序，这与源代码的配置有关。因为gradio传参不支持 dist字典，无奈只能有这种笨方法实现。如果gradio可以通过 dist 传参，那么实现会简单很多