### PR TITLE
音频播放间隔改为区间随机；闲时任务新增2种触发类型，可以根据待合成消息、待播放音频队列设置限制触发

### DIFF
--- a/config.json
+++ b/config.json
@@ -35,7 +35,8 @@
   "play_audio": {
     "enable": true,
     "text_split_enable": true,
-    "normal_interval": 0.5,
+    "normal_interval_min": 0.4,
+    "normal_interval_max": 0.5,
     "out_path": "out",
     "player": "pygame"
   },
@@ -905,10 +906,13 @@
   ],
   "idle_time_task": {
     "enable": false,
+    "type": "直播间无消息更新闲时",
     "idle_time_min": 30,
     "idle_time_max": 60,
     "wait_play_audio_num_threshold": 10,
     "idle_time_reduce_to": 0,
+    "min_msg_queue_len_to_trigger": 1,
+    "min_audio_queue_len_to_trigger": 1,
     "trigger_type": [
       "comment"
     ],

--- a/config.json.bak
+++ b/config.json.bak
@@ -35,7 +35,8 @@
   "play_audio": {
     "enable": true,
     "text_split_enable": true,
-    "normal_interval": 0.5,
+    "normal_interval_min": 0.4,
+    "normal_interval_max": 0.5,
     "out_path": "out",
     "player": "pygame"
   },
@@ -905,10 +906,13 @@
   ],
   "idle_time_task": {
     "enable": false,
+    "type": "直播间无消息更新闲时",
     "idle_time_min": 30,
     "idle_time_max": 60,
     "wait_play_audio_num_threshold": 10,
     "idle_time_reduce_to": 0,
+    "min_msg_queue_len_to_trigger": 1,
+    "min_audio_queue_len_to_trigger": 1,
     "trigger_type": [
       "comment"
     ],

--- a/utils/audio.py
+++ b/utils/audio.py
@@ -105,6 +105,29 @@ class Audio:
 
         Audio.audio_player =  AUDIO_PLAYER(self.config.get("audio_player"))
 
+    # 判断 等待合成消息队列|待播放音频队列 数是否小于或大于某个值，就返回True
+    def is_queue_less_or_greater_than(self, type: str="message_queue", less: int=None, greater: int=None):
+        if less:
+            if type == "voice_tmp_path_queue":
+                if len(Audio.voice_tmp_path_queue) < less:
+                    return True
+                return False
+            elif type == "message_queue":
+                if len(Audio.message_queue) < less:
+                    return True
+                return False
+        
+        if greater:
+            if type == "voice_tmp_path_queue":
+                if len(Audio.voice_tmp_path_queue) > greater:
+                    return True
+                return False
+            elif type == "message_queue":
+                if len(Audio.message_queue) > greater:
+                    return True
+                return False
+        
+        return False
 
     # 判断等待合成和已经合成的队列是否为空
     def is_audio_queue_empty(self):
@@ -1214,8 +1237,12 @@ class Audio:
                     if self.config.get("web_captions_printer", "enable"):
                         self.common.send_to_web_captions_printer(self.config.get("web_captions_printer", "api_ip_port"), data_json)
 
+                    normal_interval_min = self.config.get("play_audio", "normal_interval_min")
+                    normal_interval_max = self.config.get("play_audio", "normal_interval_max")
+                    normal_interval = random.uniform(normal_interval_min, normal_interval_max)
+
                     # 不仅仅是说话间隔，还是等待文本捕获刷新数据
-                    await asyncio.sleep(self.config.get("play_audio", "normal_interval"))
+                    await asyncio.sleep(normal_interval)
 
                     # 音频变速
                     random_speed = 1

--- a/utils/my_handle.py
+++ b/utils/my_handle.py
@@ -158,6 +158,19 @@ class My_handle(metaclass=SingletonMeta):
     def is_audio_queue_empty(self):
         return My_handle.audio.is_audio_queue_empty()
 
+    # 判断 等待合成消息队列|待播放音频队列 数是否小于或大于某个值，就返回True
+    def is_queue_less_or_greater_than(self, type: str="message_queue", less: int=None, greater: int=None):
+        """判断 等待合成消息队列|待播放音频队列 数是否小于或大于某个值
+
+        Args:
+            type (str, optional): _description_. Defaults to "message_queue" | voice_tmp_path_queue.
+            less (int, optional): _description_. Defaults to None.
+            greater (int, optional): _description_. Defaults to None.
+
+        Returns:
+            bool: 是否小于或大于某个值
+        """
+        return My_handle.audio.is_queue_less_or_greater_than(type, less, greater)
 
     def get_chat_model(self, chat_type, config):
         if chat_type == "claude":

--- a/webui.py
+++ b/webui.py
@@ -1362,7 +1362,8 @@ def goto_func_page():
                 if config.get("webui", "show_card", "common_config", "play_audio"):
                     config_data["play_audio"]["enable"] = switch_play_audio_enable.value
                     config_data["play_audio"]["text_split_enable"] = switch_play_audio_text_split_enable.value
-                    config_data["play_audio"]["normal_interval"] = round(float(input_play_audio_normal_interval.value), 2)
+                    config_data["play_audio"]["normal_interval_min"] = round(float(input_play_audio_normal_interval_min.value), 2)
+                    config_data["play_audio"]["normal_interval_max"] = round(float(input_play_audio_normal_interval_max.value), 2)
                     config_data["play_audio"]["out_path"] = input_play_audio_out_path.value
                     config_data["play_audio"]["player"] = select_play_audio_player.value
 
@@ -1521,6 +1522,11 @@ def goto_func_page():
                 # 闲时任务
                 if config.get("webui", "show_card", "common_config", "idle_time_task"):
                     config_data["idle_time_task"]["enable"] = switch_idle_time_task_enable.value
+                    config_data["idle_time_task"]["type"] = select_idle_time_task_type.value
+
+                    config_data["idle_time_task"]["min_msg_queue_len_to_trigger"] = int(input_idle_time_task_idle_min_msg_queue_len_to_trigger.value)
+                    config_data["idle_time_task"]["min_audio_queue_len_to_trigger"] = int(input_idle_time_task_idle_min_audio_queue_len_to_trigger.value)
+
                     config_data["idle_time_task"]["idle_time_min"] = int(input_idle_time_task_idle_time_min.value)
                     config_data["idle_time_task"]["idle_time_max"] = int(input_idle_time_task_idle_time_max.value)
                     config_data["idle_time_task"]["wait_play_audio_num_threshold"] = int(input_idle_time_task_wait_play_audio_num_threshold.value)
@@ -2761,7 +2767,9 @@ def goto_func_page():
                     with ui.row():
                         switch_play_audio_enable = ui.switch('启用', value=config.get("play_audio", "enable")).style(switch_internal_css)
                         switch_play_audio_text_split_enable = ui.switch('启用文本切分', value=config.get("play_audio", "text_split_enable")).style(switch_internal_css)
-                        input_play_audio_normal_interval = ui.input(label='普通音频播放间隔', value=config.get("play_audio", "normal_interval"), placeholder='就是弹幕回复、唱歌等音频播放结束后到播放下一个音频之间的一个间隔时间，单位：秒')
+                        input_play_audio_normal_interval_min = ui.input(label='普通音频播放间隔最小值', value=config.get("play_audio", "normal_interval_min"), placeholder='就是弹幕回复、唱歌等音频播放结束后到播放下一个音频之间的一个间隔时间，单位：秒')
+                        input_play_audio_normal_interval_max = ui.input(label='普通音频播放间隔最大值', value=config.get("play_audio", "normal_interval_max"), placeholder='就是弹幕回复、唱歌等音频播放结束后到播放下一个音频之间的一个间隔时间，单位：秒')
+                        
                         input_play_audio_out_path = ui.input(label='音频输出路径', placeholder='音频文件合成后存储的路径，支持相对路径或绝对路径', value=config.get("play_audio", "out_path"))
                         select_play_audio_player = ui.select(
                             label='播放器',
@@ -2978,6 +2986,20 @@ def goto_func_page():
                     ui.label('闲时任务')
                     with ui.row():
                         switch_idle_time_task_enable = ui.switch('启用', value=config.get("idle_time_task", "enable")).style(switch_internal_css)
+                        select_idle_time_task_type = ui.select(
+                            label='机制类型',
+                            options={
+                                '待合成消息队列更新闲时': '待合成消息队列更新闲时', 
+                                '待播放音频队列更新闲时': '待播放音频队列更新闲时', 
+                                '直播间无消息更新闲时': '直播间无消息更新闲时',
+                            },
+                            value=config.get("idle_time_task", "type")
+                        )
+                    with ui.row():
+                        input_idle_time_task_idle_min_msg_queue_len_to_trigger = ui.input(label='待合成消息队列人数小于此值时触发', value=config.get("idle_time_task", "min_msg_queue_len_to_trigger"), placeholder='最小闲时间隔时间（正整数，单位：秒），就是在没有弹幕情况下经过的时间').style("width:250px;")
+                        input_idle_time_task_idle_min_audio_queue_len_to_trigger = ui.input(label='待播放音频队列人数小于此值时触发', value=config.get("idle_time_task", "min_audio_queue_len_to_trigger"), placeholder='最小闲时间隔时间（正整数，单位：秒），就是在没有弹幕情况下经过的时间').style("width:250px;")
+                        
+                    with ui.row():
                         input_idle_time_task_idle_time_min = ui.input(label='最小闲时时间', value=config.get("idle_time_task", "idle_time_min"), placeholder='最小闲时间隔时间（正整数，单位：秒），就是在没有弹幕情况下经过的时间').style("width:150px;")
                         input_idle_time_task_idle_time_max = ui.input(label='最大闲时时间', value=config.get("idle_time_task", "idle_time_max"), placeholder='最大闲时间隔时间（正整数，单位：秒），就是在没有弹幕情况下经过的时间').style("width:150px;")
                         input_idle_time_task_wait_play_audio_num_threshold = ui.input(label='等待播放音频数量阈值', value=config.get("idle_time_task", "wait_play_audio_num_threshold"), placeholder='当等待播放音频数量超过这个阈值，将会在音频播放完毕后触发闲时时间减少到设定的缩减值，旨在控制闲时任务触发总量').style("width:150px;")


### PR DESCRIPTION
![image](https://github.com/Ikaros-521/AI-Vtuber/assets/40910637/50a600a7-9a5c-41aa-88be-e7319ae12776)
![image](https://github.com/Ikaros-521/AI-Vtuber/assets/40910637/82c8502e-0f4b-4efe-91c9-3632d0e4ae51)
在新的两个队列触发设置情况下，可以实现直播话术的播放，因为原先闲时任务的设计并不是用来播放循环的文案的，所以设置0秒的闲时间隔会导致数据爆炸，并不是正确的使用方式。
那么在现在新的 机制类型下，可以通过根据 队列的数量来进行闲时任务的触发，有效的抑制数据生成。