### PR TITLE
音频mixer初始化增加异常捕获，针对声卡异常情况下给予提示，以不影响播放逻辑运行

### DIFF
--- a/utils/audio.py
+++ b/utils/audio.py
@@ -1236,7 +1236,12 @@ class Audio:
         try:
             captions_config = self.config.get("captions")
 
-            Audio.mixer_normal.init()
+            try:
+                Audio.mixer_normal.init()
+            except Exception as e:
+                logging.error(traceback.format_exc())
+                logging.error("pygame mixer_normal初始化失败，普通音频将无法正常播放，请检查声卡是否正常！")
+
             while True:
                 try:
                     # 获取线程锁，避免同时操作
@@ -1406,7 +1411,11 @@ class Audio:
     async def only_play_copywriting(self):
         
         try:
-            Audio.mixer_copywriting.init()
+            try:
+                Audio.mixer_copywriting.init()
+            except Exception as e:
+                logging.error(traceback.format_exc())
+                logging.error("pygame mixer_copywriting初始化失败，文案音频将无法正常播放，请检查声卡是否正常！")
 
             async def random_speed_and_play(audio_path):
                 """对音频进行变速和播放，内置延时，其实就是提取了公共部分


### PR DESCRIPTION
![image](https://github.com/Ikaros-521/AI-Vtuber/assets/40910637/7949bf72-d1da-417f-adf8-0ba809fb1f2d)
```
ALSA lib pcm_dmix.c:1032:(snd_pcm_dmix_open) unable to open slave
XDG_RUNTIME_DIR (/run/user/1000) is not owned by us (uid 0), but by uid 1000! (This could e.g. happen if you try to connect to a non-root PulseAudio as a root user, over the native protocol. Don't do that.)
2024-06-12 00:00:16 - /home/wei/AITest/AI-Vtuber/utils/audio.py[line:1590] - ERROR: Traceback (most recent call last):
  File "/home/wei/AITest/AI-Vtuber/utils/audio.py", line 1413, in only_play_copywriting
    Audio.mixer_copywriting.init()
pygame.error: ALSA: Couldn't open audio device: Device or resource busy

2024-06-12 00:00:16 - /home/wei/AITest/AI-Vtuber/utils/audio.py[line:1242] - ERROR: Traceback (most recent call last):
  File "/home/wei/AITest/AI-Vtuber/utils/audio.py", line 1240, in only_play_audio
    Audio.mixer_normal.init()
pygame.error: ALSA: Couldn't open audio device: Device or resource busy
```